### PR TITLE
Allow concurrency control and fix error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ pkg
 src
 bin/wof-*
 !vendor/src
+.vscode

--- a/cmd/wof-count/main.go
+++ b/cmd/wof-count/main.go
@@ -23,8 +23,8 @@ func main() {
 	var files int64
 	var dirs int64
 
-	callback := func(path string, info os.FileInfo) error {
-		if info.IsDir() {
+	callback := func(path string, isDirectory bool) error {
+		if isDirectory {
 			atomic.AddInt64(&dirs, 1)
 			return nil
 		}

--- a/cmd/wof-count/main.go
+++ b/cmd/wof-count/main.go
@@ -3,21 +3,19 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/whosonfirst/go-whosonfirst-crawl"
 	"os"
 	"runtime"
+	"sync/atomic"
 	"time"
+
+	crawl "github.com/whosonfirst/go-whosonfirst-crawl"
 )
 
 func main() {
-
 	procs := flag.Int("processes", runtime.NumCPU()*2, "The number of concurrent processes to use")
-	nfs_kludge := flag.Bool("nfs-kludge", false, "Enable the (walk.go) NFS kludge to ignore 'readdirent: errno' 523 errors")
 
 	flag.Parse()
 	args := flag.Args()
-
-	runtime.GOMAXPROCS(*procs)
 
 	root := args[0]
 	fmt.Println("count files and directories in ", root)
@@ -26,22 +24,26 @@ func main() {
 	var dirs int64
 
 	callback := func(path string, info os.FileInfo) error {
-
 		if info.IsDir() {
-			dirs++
+			atomic.AddInt64(&dirs, 1)
 			return nil
 		}
 
-		files++
+		atomic.AddInt64(&files, 1)
 		return nil
 	}
 
 	t0 := time.Now()
 
 	c := crawl.NewCrawler(root)
-	c.NFSKludge = *nfs_kludge
+	c.CallbackConcurrency = uint(*procs)
+	c.CrawlDirectories = true
 
-	_ = c.Crawl(callback)
+	err := c.Crawl(callback)
+	if err != nil {
+		fmt.Printf("Error: %s", err)
+		os.Exit(1)
+	}
 
 	t1 := float64(time.Since(t0)) / 1e9
 	fmt.Printf("walked %d files (and %d dirs) in %.3f seconds\n", files, dirs, t1)

--- a/crawl.go
+++ b/crawl.go
@@ -1,55 +1,105 @@
 package crawl
 
 import (
-	"fmt"
-	walk "github.com/whosonfirst/walk"
+	"context"
 	"os"
+	"path/filepath"
+	"runtime"
+
+	"golang.org/x/sync/errgroup"
 )
 
 type CrawlFunc func(path string, info os.FileInfo) error
 
 type Crawler struct {
-	Root             string
-	CrawlDirectories bool
-	NFSKludge        bool // https://github.com/whosonfirst/walk/tree/master#walkwalkwithnfskludge
+	Root                string
+	CrawlDirectories    bool
+	CallbackConcurrency uint
 }
 
 func NewCrawler(path string) *Crawler {
+	cbConcurrency := uint(runtime.NumCPU() * 2)
+
 	return &Crawler{
-		Root:             path,
-		CrawlDirectories: false,
-		NFSKludge:        false,
+		Root:                path,
+		CrawlDirectories:    false,
+		CallbackConcurrency: cbConcurrency,
 	}
 }
 
+type pathInfo struct {
+	path string
+	info os.FileInfo
+}
+
+// Crawl walks through everything in Root, calling the provided callback
+// function for every file (and optionally, every directory) as it finds them.
 func (c Crawler) Crawl(cb CrawlFunc) error {
+	// Make this chan double the length of the concurrency, so there's a bit of
+	// buffer before between pushing a new file onto the chan and a worker picking
+	// it up.
+	pathChan := make(chan *pathInfo, c.CallbackConcurrency*2)
 
-	walker := func(path string, info os.FileInfo, err error) error {
+	g, ctx := errgroup.WithContext(context.Background())
 
+	var i uint
+	for i = 0; i < c.CallbackConcurrency; i++ {
+		startCallbackWorker(ctx, g, pathChan, cb)
+	}
+
+	g.Go(func() error {
+		walker := func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if info.IsDir() && !c.CrawlDirectories {
+				return nil
+			}
+
+			p := &pathInfo{path: path, info: info}
+
+			select {
+			case pathChan <- p:
+				return nil
+			case <-ctx.Done():
+				// Stop in case of an error in one of the workers
+				return ctx.Err()
+			}
+		}
+
+		err := filepath.Walk(c.Root, walker)
 		if err != nil {
 			return err
 		}
 
-		if info.IsDir() && !c.CrawlDirectories {
-			return nil
+		// We're done, so close this channel out, which signals to the workers there's
+		// nothing else to do
+		close(pathChan)
+
+		return nil
+	})
+
+	return g.Wait()
+}
+
+func startCallbackWorker(ctx context.Context, g *errgroup.Group, pathChan chan *pathInfo, cb CrawlFunc) {
+	g.Go(func() error {
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+
+			case p, more := <-pathChan:
+				if !more {
+					return nil
+				}
+
+				err := cb(p.path, p.info)
+				if err != nil {
+					return err
+				}
+			}
 		}
-
-		return cb(path, info)
-	}
-
-	var err error
-
-	// See above
-
-	if c.NFSKludge {
-		err = walk.WalkWithNFSKludge(c.Root, walker)
-	} else {
-		err = walk.Walk(c.Root, walker)
-	}
-
-	if err != nil {
-		fmt.Printf("error: %s\n", err)
-	}
-
-	return nil
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/whosonfirst/go-whosonfirst-crawl
 
-require github.com/whosonfirst/walk v0.0.0-20160802000000-c0a349674b73681a7272f5ce6ade8ea28055059f
+require golang.org/x/sync v0.0.0-20190423024810-112230192c58
 
 go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/whosonfirst/go-whosonfirst-crawl
 
-require golang.org/x/sync v0.0.0-20190423024810-112230192c58
+require (
+	github.com/karrick/godirwalk v1.10.12
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
+)
 
 go 1.12

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/whosonfirst/walk v0.0.0-20160802000000-c0a349674b73681a7272f5ce6ade8ea28055059f h1:hvKIIx2IuWmRtOdpDk29quD+t7GowpHZxz8bCfIGE58=
-github.com/whosonfirst/walk v0.0.0-20160802000000-c0a349674b73681a7272f5ce6ade8ea28055059f/go.mod h1:U/1VXxlMzNZbyylg18AzEeHkGi1RXiBCMKpaM2XR+tQ=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/karrick/godirwalk v1.10.12 h1:BqUm+LuJcXjGv1d2mj3gBiQyrQ57a0rYoAmhvJQ7RDU=
+github.com/karrick/godirwalk v1.10.12/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
Removed the dependency on `walk`, which performed a parallel walk through a directory structure, and replaced it with the single threaded `filepath/walk` from stdlib, and a pool of workers executing callbacks in parallel, as it goes, coordinated by a channel.

This has the benefit of allowing the user to control the concurrency of the callbacks, to tune it according to the operation they're running.

However, it has actually made it slower in one of my tests using `wof-count` on a 68000 file directory structure (3.2 sec vs 1.3 sec on my MBP), probably because a single threaded walk isn't as efficient. In real world usage this difference probably isn't so pronounced, because most of the effort is in whatever the callbacks are doing, not the crawl itself.

Any errors in a callback or in the walk itself are now returned correctly to the top level `Crawl` function, immediately stopping the crawl.