### PR TITLE
Fix go mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/whosonfirst/go-whosonfirst-crawl
 
 require (
 	github.com/MichaelTJones/walk v0.0.0-20161122175330-4748e29d5718 // indirect
-	github.com/whosonfirst/walk v0.0.0-20160802000000-c0a349674b73681a7272f5ce6ade8ea28055059f
+	github.com/whosonfirst/walk v0.0.0-20160803014805-c0a349674b73
 )
 
 go 1.12

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,4 @@ github.com/MichaelTJones/walk v0.0.0-20161122175330-4748e29d5718 h1:FSsoaa1q4jAa
 github.com/MichaelTJones/walk v0.0.0-20161122175330-4748e29d5718/go.mod h1:VVwKsx9Dc8rNG55BWqogoJzGubjKnRoXdUvpGbWqeCc=
 github.com/whosonfirst/walk v0.0.0-20160802000000-c0a349674b73681a7272f5ce6ade8ea28055059f h1:hvKIIx2IuWmRtOdpDk29quD+t7GowpHZxz8bCfIGE58=
 github.com/whosonfirst/walk v0.0.0-20160802000000-c0a349674b73681a7272f5ce6ade8ea28055059f/go.mod h1:U/1VXxlMzNZbyylg18AzEeHkGi1RXiBCMKpaM2XR+tQ=
+github.com/whosonfirst/walk v0.0.0-20160803014805-c0a349674b73/go.mod h1:U/1VXxlMzNZbyylg18AzEeHkGi1RXiBCMKpaM2XR+tQ=


### PR DESCRIPTION
Go mod was complaining that:

```
go: github.com/whosonfirst/go-whosonfirst-crawl@v0.1.1-0.20190822225219-b571d777dc43 requires
        github.com/whosonfirst/walk@v0.0.0-20160802000000-c0a349674b73681a7272f5ce6ade8ea28055059f: invalid pseudo-version: revision is longer than canonical (c0a349674b73)
```

I followed [this guide](https://golang.org/doc/go1.13) to let `go mod tidy` rebuild the reference and it seems fine now.